### PR TITLE
Deduplicate clippy warning annotations

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -79,11 +79,12 @@ jobs:
       - uses: swlynch99/cargo-sweep-action@v1
       - uses: taiki-e/install-action@v2
         with:
-          tool: clippy-sarif,sarif-fmt
+          tool: clippy-sarif,sarif-fmt,cargo-deduplicate-warnings
 
       - name: cargo clippy
         run: |
           cargo clippy --all-targets --all-features --message-format json \
+            | cargo deduplicate-warnings \
             | clippy-sarif      \
             | tee clippy.sarif  \
             | sarif-fmt


### PR DESCRIPTION
When clippy is used with --message-format json it will emit warnings in the main crate twice. This shows up on github as duplicate warnings which isn't great. This PR just adds a CI step that deduplicates warnings before sending them off to clippy-sarif and sarif-fmt.